### PR TITLE
Option to skip rewards display. Plotscripting commands to return rewards from the most recent battle

### DIFF
--- a/battle_udts.bi
+++ b/battle_udts.bi
@@ -273,21 +273,6 @@ ENUM BattleMenuItemType
  batmenu_SKIPTURN
 END ENUM
 
-'This type is just used by RewardState
-TYPE RewardsStateItem
- id as integer    'Not offset
- num as integer   'num = 0 indcates slot not used
-END TYPE
-
-'The rewards gathered in the current battle
-TYPE RewardsState
- plunder as integer
- exper as integer
- found(16) as RewardsStateItem
-
- DECLARE SUB add_item(itemid as integer, count as integer = 1)
-END TYPE
-
 'These handle the state of the currently displaying spell menu
 TYPE SpellMenuItem
  name as string

--- a/battle_udts.bi
+++ b/battle_udts.bi
@@ -9,6 +9,7 @@
 'so as to prevent them from cluttering up the global udts.bi file
 
 #include "slices.bi"
+#include "game_udts.bi"
 
 UNION BattleStatsSingle
   'See also Stats '-- the two of these can probably be unified eventually

--- a/bmod.rbas
+++ b/bmod.rbas
@@ -38,7 +38,6 @@ DECLARE SUB reset_battle_state (byref bat as BattleState)
 DECLARE SUB reset_targetting (byref bat as BattleState)
 DECLARE SUB reset_attack (byref bat as BattleState)
 DECLARE SUB reset_victory_state (byref vic as VictoryState)
-DECLARE SUB reset_rewards_state (byref rew as RewardsState)
 DECLARE SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as integer)
 DECLARE SUB trigger_victory(byref bat as BattleState, bslot() as BattleSprite)
 DECLARE SUB fulldeathcheck (byval killing_attack as integer, bat as BattleState, bslot() as BattleSprite, formdata as Formation)
@@ -2912,19 +2911,6 @@ SUB reset_attack (byref bat as BattleState)
   .non_elemental = NO
   FOR i = 0 TO UBOUND(.elemental)
   .elemental(i) = NO
-  NEXT i
- END WITH
-END SUB
-
-SUB reset_rewards_state (byref rew as RewardsState)
- 'This could become a constructor for RewardsState when we support the -lang fb dialect
- DIM i as integer
- WITH rew
-  .plunder = 0
-  .exper = 0
-  FOR i = 0 TO UBOUND(.found)
-   .found(i).id = 0   'Note: id is not offset; num=0 indicates slot not used
-   .found(i).num = 0
   NEXT i
  END WITH
 END SUB

--- a/bmod.rbas
+++ b/bmod.rbas
@@ -2738,7 +2738,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
   SELECT CASE .state
    CASE vicGOLDEXP
     '--print acquired gold and experience
-    IF gen(genDefaultBattleMenu) >= 0 AND (bat.rew.plunder > 0 OR bat.rew.exper > 0) THEN draw_victory_box 4, page
+    IF bat.rew.plunder > 0 OR bat.rew.exper > 0 THEN draw_victory_box 4, page
     IF bat.rew.plunder > 0 THEN
      tempstr = .gold_caption & " " & price_string(bat.rew.plunder) & "!"
      edgeprint tempstr, pCentered, 16, uilook(uiText), page
@@ -2757,9 +2757,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
     FOR i as integer = 0 TO UBOUND(gam.hero)
      IF gam.hero(i).lev_gain <> 0 THEN numlevelled += 1
     NEXT
-    IF gen(genDefaultBattleMenu) >= 0 AND numlevelled THEN
-     draw_victory_box large(numlevelled, 4), page
-    END IF
+    IF numlevelled THEN draw_victory_box large(numlevelled, 4), page
     FOR i as integer = 0 TO UBOUND(gam.hero)
      SELECT CASE gam.hero(i).lev_gain
       CASE 1
@@ -2807,7 +2805,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
      IF should_victory_advance(bat) THEN
       .showlearn = NO ' hide the display (which causes us to search for the next learned spell)
      END IF
-     IF gen(genDefaultBattleMenu) >= 0 THEN draw_victory_box 4, page
+     draw_victory_box 4, page
      edgeprint .item_name, pCenteredLeft, 22, uilook(uiText), page
     END IF
    CASE vicITEMS
@@ -2831,7 +2829,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
     ELSE
      tempstr = .plural_item_caption & " " & pickedup.num & " " & .item_name
     END IF
-    IF gen(genDefaultBattleMenu) >= 0 THEN draw_victory_box 4, page
+    draw_victory_box 4, page
     edgeprint tempstr, pCenteredLeft, 22, uilook(uiText), page
     '--check for a keypress
     IF should_victory_advance(bat) THEN

--- a/bmod.rbas
+++ b/bmod.rbas
@@ -306,7 +306,13 @@ FUNCTION battle (byval form as integer) as bool
   battle_display_menus bat, bslot(), st(), uipage
 
   IF bat.vic.state = vicEXITDELAY THEN bat.vic.state = vicEXIT
-  IF bat.vic.state > vicNONE THEN show_victory bat, bslot(), uipage
+  IF bat.vic.state > vicNONE THEN
+   IF gen(genSkipBattleRewardsTicks) = -1 THEN
+    bat.vic.state = vicEXITDELAY
+   ELSE
+    show_victory bat, bslot(), uipage
+   END IF
+  END IF
 
   IF bat.death_mode = deathENEMIES AND bat.vic.state = vicNONE THEN
    IF count_dissolving_enemies(bslot()) = 0 THEN trigger_victory bat, bslot()
@@ -2629,11 +2635,21 @@ SUB trigger_victory(byref bat as BattleState, bslot() as BattleSprite)
  '--Collect gold (which is capped at 2 billion max)
  gold = gold + bat.rew.plunder
  IF gold < 0 OR gold > 2000000000 THEN gold = 2000000000
- '--Give out experience
 
+ '--Give out experience
  export_battle_hero_stats bslot() 'Needed because distribute_party_experience() might level-up some heroes
  bat.rew.exper = distribute_party_experience(bat.rew.exper)
  import_battle_hero_stats bslot() 'Needed because we will likely be calling export_battle_hero_stats() again later
+
+ '--Give items
+ DIM i as integer = 0
+ FOR i = 0 TO UBOUND(bat.rew.found)
+  IF bat.rew.found(i).num > 0 THEN getitem bat.rew.found(i).id, bat.rew.found(i).num
+ NEXT
+
+ '-- Record rewards for after-battle usage
+ gam.rew = bat.rew
+
  '--Trigger the display of end-of-battle rewards
  bat.vic.state = vicGOLDEXP
  bat.vic.display_ticks = 0
@@ -2700,7 +2716,7 @@ SUB RewardsState.add_item(itemid as integer, count as integer = 1)
 END SUB
 
 FUNCTION should_victory_advance(byref bat as BattleState) as bool
- IF game_check_use_key() ORELSE game_check_cancel_key() THEN RETURN YES
+ IF gen(genSkipBattleRewardsTicks) = -1 ORELSE game_check_use_key() ORELSE game_check_cancel_key() THEN RETURN YES
  IF (readmouse.release AND mouseLeft) ORELSE (readmouse.release AND mouseLeft) THEN RETURN YES
  IF gen(genSkipBattleRewardsTicks) > 0 THEN
   IF bat.vic.display_ticks > gen(genSkipBattleRewardsTicks) THEN
@@ -2722,7 +2738,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
   SELECT CASE .state
    CASE vicGOLDEXP
     '--print acquired gold and experience
-    IF bat.rew.plunder > 0 OR bat.rew.exper > 0 THEN draw_victory_box 4, page
+    IF gen(genDefaultBattleMenu) >= 0 AND (bat.rew.plunder > 0 OR bat.rew.exper > 0) THEN draw_victory_box 4, page
     IF bat.rew.plunder > 0 THEN
      tempstr = .gold_caption & " " & price_string(bat.rew.plunder) & "!"
      edgeprint tempstr, pCentered, 16, uilook(uiText), page
@@ -2741,7 +2757,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
     FOR i as integer = 0 TO UBOUND(gam.hero)
      IF gam.hero(i).lev_gain <> 0 THEN numlevelled += 1
     NEXT
-    IF numlevelled THEN
+    IF gen(genDefaultBattleMenu) >= 0 AND numlevelled THEN
      draw_victory_box large(numlevelled, 4), page
     END IF
     FOR i as integer = 0 TO UBOUND(gam.hero)
@@ -2791,7 +2807,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
      IF should_victory_advance(bat) THEN
       .showlearn = NO ' hide the display (which causes us to search for the next learned spell)
      END IF
-     draw_victory_box 4, page
+     IF gen(genDefaultBattleMenu) >= 0 THEN draw_victory_box 4, page
      edgeprint .item_name, pCenteredLeft, 22, uilook(uiText), page
     END IF
    CASE vicITEMS
@@ -2807,8 +2823,6 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
      END IF
      '--get the item name
      .item_name = readitemname(pickedup.id)
-     '--actually acquire the item
-     getitem pickedup.id, pickedup.num
      'tag_updates called when exiting battle() to handle all at once
     END IF
     '--if the present item is gotten, show the caption
@@ -2817,7 +2831,7 @@ SUB show_victory (byref bat as BattleState, bslot() as BattleSprite, page as int
     ELSE
      tempstr = .plural_item_caption & " " & pickedup.num & " " & .item_name
     END IF
-    draw_victory_box 4, page
+    IF gen(genDefaultBattleMenu) >= 0 THEN draw_victory_box 4, page
     edgeprint tempstr, pCenteredLeft, 22, uilook(uiText), page
     '--check for a keypress
     IF should_victory_advance(bat) THEN
@@ -2883,6 +2897,7 @@ SUB reset_battle_state (byref bat as BattleState)
  reset_attack bat
  reset_victory_state bat.vic
  reset_rewards_state bat.rew
+ reset_rewards_state gam.rew
 END SUB
 
 SUB reset_targetting (byref bat as BattleState)

--- a/const.bi
+++ b/const.bi
@@ -194,7 +194,7 @@ CONST genFullscreen = 210       ' Whether to start in fullscreen by default
 CONST genMusicVolume = 211      ' Initial music volume as a percentage.
 CONST genSFXVolume = 212        ' Initial global sound effects volume as a percentage.
 CONST genRungameFullscreenIndependent = 213  ' If false, fullscreen settings/config for games spawned by rungame are ignored
-CONST genSkipBattleRewardsTicks = 214   ' If > 0 then the battle rewards messages will automatically advance after this many ticks
+CONST genSkipBattleRewardsTicks = 214   ' If > 0 then the battle rewards messages will automatically advance after this many ticks; if = -1 then the battle rewards messages are skipped
 CONST genDefOnkeypressScript = 215      ' Default on-keypress script, if not overridden by map
 CONST genDefEachStepScript = 216        ' Default each-step script, if not overridden by map
 CONST genDefAfterBattleScript = 217     ' Default after-battle script, if not overridden by map
@@ -350,7 +350,7 @@ CONST scriptTableSize = 512  'hash table size, power of 2 please
 CONST scriptCheckDelay = 1.1     'How long, in seconds, before the script interpreter becomes interruptable
 CONST scriptCheckInterval = 0.1  'How often, in seconds, that the script interpreter should perform checks
 
-CONST maxScriptCmdID = 798  'Max ID number of any supported script command (checked when saving or loading game)
+CONST maxScriptCmdID = 802  'Max ID number of any supported script command (checked when saving or loading game)
 
 '--- Binary files in BINSIZE.BIN for getbinsize()
 CONST binATTACK = 0

--- a/docs/platformdict.xml
+++ b/docs/platformdict.xml
@@ -44,7 +44,7 @@
 	<!ELEMENT b            (#PCDATA)>
 ]>
 
-<plotscript version="wip" datecode="2025-08-04">
+<plotscript version="wip" datecode="2025-08-05">
 	<title>
 		Additional Platform Script Commands
 	</title>

--- a/docs/platformdict.xml
+++ b/docs/platformdict.xml
@@ -44,7 +44,7 @@
 	<!ELEMENT b            (#PCDATA)>
 ]>
 
-<plotscript version="wip" datecode="2025-08-05">
+<plotscript version="wip" datecode="2025-08-07">
 	<title>
 		Additional Platform Script Commands
 	</title>

--- a/docs/plotdict.xml
+++ b/docs/plotdict.xml
@@ -191,7 +191,7 @@ same level.)
 	~ Monorail guy, Simpsons
 
 -->
-<plotscript version="wip" datecode="2025-08-04">
+<plotscript version="wip" datecode="2025-08-05">
 	<title>
 		Dictionary of Plotscripting Commands
 	</title>
@@ -3320,6 +3320,11 @@ if (slot > 0) then (load from slot (slot))</example>
 			<shortname>room in active party</shortname>
 			<description>A function that returns the number of available spaces in your active party. It will return zero or <ref>false</ref> if there is no room.</description>
 		</command>
+		<command id="experiencereward">
+			<canon>experience reward</canon>
+			<shortname>experience reward</shortname>
+			<description>Returns the total experience given by enemies as reward in the most recent battle (or 0 if no battles have been fought so far).</description>
+		</command>
 		</section>		<!-- Inspecting the Party-->
 
 		<section title="Changing the Party">
@@ -3524,6 +3529,11 @@ end, else, begin
 	show text box(61) # ha ha, no uber sword for you!
 	wait for text box
 end</example>
+		</command>
+		<command id = "moneyreward">
+			<canon>money reward</canon>
+			<shortname>money reward</shortname>
+			<description>Returns how much money the party gained in the most recent battle (0 if there have been no battles so far).</description>
 		</command>
 	</section>
 
@@ -3800,6 +3810,44 @@ end</example>
 				Moves all items to the top of the inventory and reorders them according to the
 				"Inventory autosort" setting in General Game Settings.
 			</description>
+		</command>
+		<command id="itemsreward">
+			<canon>items reward (number)</canon>
+			<shortname>items reward</shortname>
+			<description>
+				Returns the id numbers of the items dropped by enemies in the last battle
+				(-1 if item reward number is not present).
+				If the argument is <ref>getcount</ref>, then it returns the number of distinct
+				items acquired at the end of the battle.
+				You can use it in a loop in order to display all item rewards (for example, in
+				an after battle script), usually in tandem with <ref>itemsquantityreward</ref>.
+				<example>script, print items gained, begin
+  # assume text box 123 contains text "Got ${S0} x ${S1}."
+  variable (idx)
+  for (idx, 0, items reward (get count) -- 1) do (
+    clear string (0)
+    append number (0, items quantity reward (idx))
+    get item name (1, items reward (idx))
+    show text box (123) # this should display e.g. "Got 2 x Herb."
+    wait for text box
+  )
+end</example>
+
+			</description>
+			<seealso>
+				<ref>itemsquantityreward</ref>
+			</seealso>
+		</command>
+		<command id="itemsquantityreward">
+			<canon>items quantity reward (number)</canon>
+			<shortname>items quantity reward</shortname>
+			<description>
+				Similar to <ref>itemsreward</ref>, except it returns the quantities of corresponding
+				items acquired in the last battle.
+			</description>
+			<seealso>
+				<ref>itemsreward</ref>
+			</seealso>
 		</command>
 
 		</section>		<!--Inventory-->

--- a/docs/plotdict.xml
+++ b/docs/plotdict.xml
@@ -191,7 +191,7 @@ same level.)
 	~ Monorail guy, Simpsons
 
 -->
-<plotscript version="wip" datecode="2025-08-05">
+<plotscript version="wip" datecode="2025-08-07">
 	<title>
 		Dictionary of Plotscripting Commands
 	</title>
@@ -3816,12 +3816,14 @@ end</example>
 			<shortname>items reward</shortname>
 			<description>
 				Returns the id numbers of the items dropped by enemies in the last battle
-				(-1 if item reward number is not present).
+				(-1 if item reward <p>number</p> is not present).
+				<p>number</p> counts from 0 up, where <tt>items reward(0)</tt> is the ID of
+				the first gained item, etc.
 				If the argument is <ref>getcount</ref>, then it returns the number of distinct
 				items acquired at the end of the battle.
 				You can use it in a loop in order to display all item rewards (for example, in
 				an after battle script), usually in tandem with <ref>itemsquantityreward</ref>.
-				<example>script, print items gained, begin
+				<example>plotscript, print items gained, begin
   # assume text box 123 contains text "Got ${S0} x ${S1}."
   variable (idx)
   for (idx, 0, items reward (get count) -- 1) do (

--- a/docs/plotdictionary.html
+++ b/docs/plotdictionary.html
@@ -213,7 +213,7 @@ function toggleContent(target) {
 <h1>
 		Dictionary of Plotscripting Commands
 	</h1>
-<h2>For the next WIP OHRRPGCE version (nightly build 2025-08-05)</h2>
+<h2>For the next WIP OHRRPGCE version (nightly build 2025-08-07)</h2>
 		This is the documentation for all <a href="https://rpg.hamsterrepublic.com/ohrrpgce/Plotscripting">plotscripting</a> commands.
 		In addition to reading this document, we also recommend you check out the
 		<a href="https://rpg.hamsterrepublic.com/ohrrpgce/Plotscripting_Tutorial">Plotscripting Tutorial</a>
@@ -7407,12 +7407,14 @@ end</pre>
 <p>
 			
 				Returns the id numbers of the items dropped by enemies in the last battle
-				(-1 if item reward number is not present).
+				(-1 if item reward <span class="param">number</span> is not present).
+				<span class="param">number</span> counts from 0 up, where <span class="code">items reward(0)</span> is the ID of
+				the first gained item, etc.
 				If the argument is <a href="#about-getcount" class="ref">get count</a>, then it returns the number of distinct
 				items acquired at the end of the battle.
 				You can use it in a loop in order to display all item rewards (for example, in
 				an after battle script), usually in tandem with <a href="#about-itemsquantityreward" class="ref">items quantity reward</a>.
-				<pre>script, print items gained, begin
+				<pre>plotscript, print items gained, begin
   # assume text box 123 contains text "Got ${S0} x ${S1}."
   variable (idx)
   for (idx, 0, items reward (get count) -- 1) do (

--- a/docs/plotdictionary.html
+++ b/docs/plotdictionary.html
@@ -213,7 +213,7 @@ function toggleContent(target) {
 <h1>
 		Dictionary of Plotscripting Commands
 	</h1>
-<h2>For the next WIP OHRRPGCE version (nightly build 2025-08-04)</h2>
+<h2>For the next WIP OHRRPGCE version (nightly build 2025-08-05)</h2>
 		This is the documentation for all <a href="https://rpg.hamsterrepublic.com/ohrrpgce/Plotscripting">plotscripting</a> commands.
 		In addition to reading this document, we also recommend you check out the
 		<a href="https://rpg.hamsterrepublic.com/ohrrpgce/Plotscripting_Tutorial">Plotscripting Tutorial</a>
@@ -818,6 +818,7 @@ function toggleContent(target) {
 		<a href="#about-exitscript" class="ref">exit script</a><br>
 		<a href="#about-expandstring" class="ref">expand string(ID, saveslot)</a><br>
 		<a href="#about-expandstringsinslices" class="ref">expand strings in slices(handle, saveslot)</a><br>
+		<a href="#about-experiencereward" class="ref">experience reward</a><br>
 		<a href="#about-experiencetolevel" class="ref">experience to level (level, hero slot)</a><br>
 		<a href="#about-experiencetonextlevel" class="ref">experience to next level (who)</a><br>
 		<a href="#about-exponent" class="ref">number ^ power</a><br>
@@ -1108,6 +1109,8 @@ function toggleContent(target) {
 		<a href="#about-itemcountinslot" class="ref">item count in slot (slot)</a><br>
 		<a href="#about-iteminslot" class="ref">item in slot (slot)</a><br>
 		<a href="#about-itemsmenu" class="ref">items menu</a><br>
+		<a href="#about-itemsquantityreward" class="ref">items quantity reward (number)</a><br>
+		<a href="#about-itemsreward" class="ref">items reward (number)</a><br>
 		<a href="#about-joystickaxis" class="ref">joystick axis (axis, multiplier, player)</a><br>
 		<a href="#about-joystickbutton" class="ref">joystick button (button, player)</a><br>
 		<a href="#about-controlcodes" class="ref">Key Constants</a><br>
@@ -1183,6 +1186,7 @@ function toggleContent(target) {
 		<a href="#about-milliseconds" class="ref">milliseconds</a><br>
 		<a href="#about-minutesofplay" class="ref">minutes of play</a><br>
 		<a href="#about-modulus" class="ref">number,mod,number</a><br>
+		<a href="#about-moneyreward" class="ref">money reward</a><br>
 		<a href="#about-mousebutton" class="ref">mouse button (which)</a><br>
 		<a href="#about-mouseclick" class="ref">mouse click (which)</a><br>
 		<a href="#about-mouseconstants" class="ref">Mouse Constants</a><br>
@@ -6487,6 +6491,7 @@ if (slot &gt; 0) then (load from slot (slot))</pre>
 		<a href="#about-rankincaterpillar" class="ref">rank in caterpillar (who)</a><br>
 		<a href="#about-herobyrank" class="ref">hero by rank (where)</a><br>
 		<a href="#about-roominactiveparty" class="ref">room in active party</a><br>
+		<a href="#about-experiencereward" class="ref">experience reward</a><br>
 </ul>
 <ul></ul>
 </li>
@@ -6579,6 +6584,16 @@ if (slot &gt; 0) then (load from slot (slot))</pre>
 				<h4>room in active party</h4>
 <p>
 			A function that returns the number of available spaces in your active party. It will return zero or <a href="#about-false" class="ref">false</a> if there is no room.
+			
+			
+			
+		</p>
+</div>
+		<div class="command">
+			<a name="about-experiencereward"></a>
+				<h4>experience reward</h4>
+<p>
+			Returns the total experience given by enemies as reward in the most recent battle (or 0 if no battles have been fought so far).
 			
 			
 			
@@ -6836,6 +6851,7 @@ if (slot &gt; 0) then (load from slot (slot))</pre>
 		<a href="#about-losemoney" class="ref">lose money (amount)</a><br>
 		<a href="#about-setmoney" class="ref">set money (amount)</a><br>
 		<a href="#about-paymoney" class="ref">pay money (amount)</a><br>
+		<a href="#about-moneyreward" class="ref">money reward</a><br>
 </div></ul>
 </div>
 		<div class="command">
@@ -6893,6 +6909,16 @@ end</pre>
 			
 		</p>
 </div>
+		<div class="command">
+			<a name="about-moneyreward"></a>
+				<h4>money reward</h4>
+<p>
+			Returns how much money the party gained in the most recent battle (0 if there have been no battles so far).
+			
+			
+			
+		</p>
+</div>
 		<hr>
 		</div>
 		<div class="section">
@@ -6932,6 +6958,8 @@ end</pre>
 		<a href="#about-getinventorysize" class="ref">get inventory size</a><br>
 		<a href="#about-setinventorysize" class="ref">set inventory size (new size)</a><br>
 		<a href="#about-sortinventory" class="ref">sort inventory</a><br>
+		<a href="#about-itemsreward" class="ref">items reward (number)</a><br>
+		<a href="#about-itemsquantityreward" class="ref">items quantity reward (number)</a><br>
 </ul>
 <ul></ul>
 </li>
@@ -7371,6 +7399,50 @@ end</pre>
 			
 			
 			
+		</p>
+</div>
+		<div class="command">
+			<a name="about-itemsreward"></a>
+				<h4>items reward (number)</h4>
+<p>
+			
+				Returns the id numbers of the items dropped by enemies in the last battle
+				(-1 if item reward number is not present).
+				If the argument is <a href="#about-getcount" class="ref">get count</a>, then it returns the number of distinct
+				items acquired at the end of the battle.
+				You can use it in a loop in order to display all item rewards (for example, in
+				an after battle script), usually in tandem with <a href="#about-itemsquantityreward" class="ref">items quantity reward</a>.
+				<pre>script, print items gained, begin
+  # assume text box 123 contains text "Got ${S0} x ${S1}."
+  variable (idx)
+  for (idx, 0, items reward (get count) -- 1) do (
+    clear string (0)
+    append number (0, items quantity reward (idx))
+    get item name (1, items reward (idx))
+    show text box (123) # this should display e.g. "Got 2 x Herb."
+    wait for text box
+  )
+end</pre>
+
+			
+			
+			
+			<div class="seealso">See also: <ul><li><a href="#about-itemsquantityreward" class="ref">items quantity reward</a></li></ul>
+</div>
+		</p>
+</div>
+		<div class="command">
+			<a name="about-itemsquantityreward"></a>
+				<h4>items quantity reward (number)</h4>
+<p>
+			
+				Similar to <a href="#about-itemsreward" class="ref">items reward</a>, except it returns the quantities of corresponding
+				items acquired in the last battle.
+			
+			
+			
+			<div class="seealso">See also: <ul><li><a href="#about-itemsreward" class="ref">items reward</a></li></ul>
+</div>
 		</p>
 </div>
 		<hr>
@@ -23843,7 +23915,7 @@ run key            # Alias for 'flee key'
 </div>
 		<hr>
 		</div>
-<p>Stats: There are 990 commands (of which 15 are aliases), 27 constants and 19 definitions of types and other terms in this file.</p>
+<p>Stats: There are 994 commands (of which 15 are aliases), 27 constants and 19 definitions of types and other terms in this file.</p>
 <p>This file was generated from an XML file. The contents were painstakingly transcribed by Mike Caron from the original Plotscripting Dictionary, which was created by James Paige.</p>
 </body>
 </html>

--- a/game_udts.bi
+++ b/game_udts.bi
@@ -107,6 +107,21 @@ TYPE NPCSliceContext EXTENDS SliceContext
   npcindex as NPCIndex
 END TYPE
 
+'This type is just used by RewardState
+TYPE RewardsStateItem
+ id as integer    'Not offset
+ num as integer   'num = 0 indcates slot not used
+END TYPE
+
+'The rewards gathered in a battle
+TYPE RewardsState
+ plunder as integer
+ exper as integer
+ found(16) as RewardsStateItem
+
+ DECLARE SUB add_item(itemid as integer, count as integer = 1)
+END TYPE
+
 TYPE ScriptLoggingState
   enabled as bool
   filename as string

--- a/game_udts.bi
+++ b/game_udts.bi
@@ -256,6 +256,7 @@ TYPE GameState
   hero_pathing(3) as HeroPathing
   stillticks(3) as integer           'keeps track of how long a hero has been standing still
   pathing_click_start as double
+  rew as RewardsState                'keeps track of rewards gained in the most recent battle
 END TYPE
 
 'Note that .showing, .fully_shown, .sayer need to be always correct even if no box is up

--- a/generaledit.rbas
+++ b/generaledit.rbas
@@ -1561,7 +1561,9 @@ SUB generate_battlesystem_menu(menu() as string, enabled() as bool, greyout() as
   menu(22) = "Default Enemy Dissolve: " & dissolve_type_caption(gen(genEnemyDissolve))
   menu(23) = "Damage Display Time: " & gen(genDamageDisplayTicks) & " ticks (" & seconds_estimate(gen(genDamageDisplayTicks)) & " sec)"
   menu(24) = "Damage Display Rises: " & gen(genDamageDisplayRise) & " pixels"
-  menu(25) = "Rewards Display: " & IIF(gen(genSkipBattleRewardsTicks) = 0, "Wait for keypress", gen(genSkipBattleRewardsTicks) & " ticks (" & seconds_estimate(gen(genSkipBattleRewardsTicks)) & " secs)")
+  menu(25) = "Rewards Display: " & IIF(gen(genSkipBattleRewardsTicks) = 0, "Wait for keypress", _
+                                       IIF(gen(genSkipBattleRewardsTicks) = -1, "Do not show rewards", _
+                                           gen(genSkipBattleRewardsTicks) & " ticks (" & seconds_estimate(gen(genSkipBattleRewardsTicks)) & " secs)"))
 
   enabled(26) = NO
   menu(27) = " Other Defaults"
@@ -1640,7 +1642,7 @@ SUB battleoptionsmenu ()
   min(24) = -1000
   index(25) = genSkipBattleRewardsTicks
   max(25) = 100000
-  min(25) = 0
+  min(25) = -1
   index(28) = genDefCounterProvoke
   max(28) = provokeLAST
   min(28) = 1  ' Can't select 'Default'

--- a/moresubs.bi
+++ b/moresubs.bi
@@ -48,6 +48,7 @@ DECLARE SUB resetgame ()
 DECLARE SUB reset_levelmp (byref hero as HeroState)
 DECLARE SUB reset_game_state ()
 DECLARE SUB reset_map_state (map as MapModeState)
+DECLARE SUB reset_rewards_state (byref rew as RewardsState)
 
 DECLARE SUB shop (byval id as integer)
 DECLARE FUNCTION useinn (byval price as integer, byval holdscreen as integer) as bool

--- a/moresubs.rbas
+++ b/moresubs.rbas
@@ -1543,11 +1543,25 @@ DESTRUCTOR HeroWalkabout ()
  v_free curzones
 END DESTRUCTOR
 
+SUB reset_rewards_state (byref rew as RewardsState)
+ 'This could become a constructor for RewardsState when we support the -lang fb dialect
+ DIM i as integer
+ WITH rew
+  .plunder = 0
+  .exper = 0
+  FOR i = 0 TO UBOUND(.found)
+   .found(i).id = 0   'Note: id is not offset; num=0 indicates slot not used
+   .found(i).num = 0
+  NEXT i
+ END WITH
+END SUB
+
 'Unlike resetgame(), this is called before a game first is played,
 'in addition to being called after playing (resetgame/gameover/loadgame/quit).
 SUB reset_game_state ()
  reset_map_state(gam.map)
  gam.wonbattle = NO
+ reset_rewards_state gam.rew
  gam.remembermusic = -1
  gam.random_battle_countdown = range(100, 60)
  gam.mouse_enabled = NO

--- a/ohrhelp/general_battle_bitsets.txt
+++ b/ohrhelp/general_battle_bitsets.txt
@@ -45,6 +45,7 @@ This does everything the next two bits do, and more. If ON, those bits have no e
 
 "Randomize initial ready meters" determines whether at the beginning of battle, ready meters have random values, or start empty.
 
+"Rewards display" determines whether and for how long rewards (dropped items, experience, money) are displayed at the end of the battle.
 
  Turn-based Battle Options
 

--- a/plotscr.hsd
+++ b/plotscr.hsd
@@ -834,6 +834,10 @@ define function, begin
 796,unlockherobyslot,1,-1     # Undo lockhero (party slot)
 797,getitemweaponpic,1,0      # get the weapon sprite number of an item
 798,getitemweaponpal,1,0      # get the weapon sprite palette number of an item or -1 for default
+799,moneyreward,0             # Return money gained from the last battle, or 0 if N/A
+800,experiencereward,0        # Return experience reward from the last battle, or 0 if N/A
+801,itemsreward,1,0           # Number ids of items gained as rewards in last battle (-1 for N/A)
+802,itemsquantityreward,1,0   # Number quantities of items gained as rewards in last battle (0 for N/A)
 
 # Don't forget to update maxScriptCmdID in const.bi when adding new commands
 end

--- a/scriptcommands.bas
+++ b/scriptcommands.bas
@@ -5486,6 +5486,30 @@ SUB script_commands(byval cmdid as integer)
    loaditemdata item, retvals(0)
    scriptret = item.wep_pal
   END IF
+ CASE 799 '--money reward
+  scriptret = gam.rew.plunder
+ CASE 800 '--experience reward
+  scriptret = gam.rew.exper
+ CASE 801, /'--items reward idx'/ 802 /'--items quantity reward itx'/
+  DIM i as integer = retvals(0)
+  DIM j as integer = 0
+  WITH gam.rew
+   IF i = -1 THEN 'getcount
+    scriptret = 0
+    FOR j = 0 to UBOUND(.found)
+     IF .found(j).num > 0 THEN scriptret = j + 1
+    NEXT
+   ELSE
+    scriptret = IIF(cmdid = 801, -1, 0)
+    IF 0 <= i AND i <= UBOUND(.found) THEN
+     IF .found(i).num = 0 THEN
+      scriptret = IIF(cmdid = 801, -1, 0)
+     ELSE
+      scriptret = IIF(cmdid = 801, .found(i).id, .found(i).num)
+     END IF
+    END IF
+   END IF
+  END WITH
 
  CASE ELSE
   'We also check the HSP header at load time to check there aren't unsupported commands

--- a/udts.bi
+++ b/udts.bi
@@ -47,6 +47,21 @@ TYPE MenuSet
   itemfile as string
 END TYPE
 
+'This type is just used by RewardState
+TYPE RewardsStateItem
+ id as integer    'Not offset
+ num as integer   'num = 0 indcates slot not used
+END TYPE
+
+'The rewards gathered in a battle
+TYPE RewardsState
+ plunder as integer
+ exper as integer
+ found(16) as RewardsStateItem
+
+ DECLARE SUB add_item(itemid as integer, count as integer = 1)
+END TYPE
+
 TYPE BasicMenuItem
   text as string    'This is the caption actually displayed (unlike MenuDefItem.caption)
   'In MenuDefItems the following aren't saved.

--- a/udts.bi
+++ b/udts.bi
@@ -47,21 +47,6 @@ TYPE MenuSet
   itemfile as string
 END TYPE
 
-'This type is just used by RewardState
-TYPE RewardsStateItem
- id as integer    'Not offset
- num as integer   'num = 0 indcates slot not used
-END TYPE
-
-'The rewards gathered in a battle
-TYPE RewardsState
- plunder as integer
- exper as integer
- found(16) as RewardsStateItem
-
- DECLARE SUB add_item(itemid as integer, count as integer = 1)
-END TYPE
-
 TYPE BasicMenuItem
   text as string    'This is the caption actually displayed (unlike MenuDefItem.caption)
   'In MenuDefItems the following aren't saved.

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -3,8 +3,12 @@ WHAT IS NEW?
 Nov ?? 2025 [Lexiphanic]
 
   *** New Features
+   * New general battle system option to not display rewards at the end of a
+   battle. Useful if you create your own way of displaying rewards. [Dre]
 
    * Plotscripting Features
+    * Commands to access rewards from the latest battle: "money reward",
+      "experience reward", "items reward", "items quantity reward". [Dre]
 
   *** Changes
 


### PR DESCRIPTION
- Moves `RewardsState` outside `battle_udts.bi`.
- Most recent rewards are now part of the game state (`rew` field)
- Awarding items after battle is no longer tied to the victory animation logic.
- New scripting commands for accessing the "most recent reward" part of the game state.