### PR TITLE
Fix distrib-web.sh to create ./distrib if it does not already exist

### DIFF
--- a/distrib-web.sh
+++ b/distrib-web.sh
@@ -13,7 +13,8 @@ cd "${SCRIPTDIR}"
 # Show current emscripten version
 /emsdk/upstream/emscripten/emcc --version | head -1
 
-mkdir ./games
+mkdir -p ./distrib
+mkdir -p ./games
 cp -p testgame/inputtest.rpg ./games
 cp -p testgame/collider.rpg ./games
 cp -p testgame/turntest.rpg ./games


### PR DESCRIPTION
Fix the breakage of the emscripten web port nightly builds.

(Also I am testing out github PRs, after fixing my previously broken upstream fork metadata)